### PR TITLE
Use Next.js Link for internal navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Footer from "./components/Footer";
+import Link from "next/link";
 
 export default function HomePage() {
   return (
@@ -6,10 +7,18 @@ export default function HomePage() {
       <h1 className="text-4xl font-bold mb-6">📊 투자 정보 플랫폼 - InvestingKorea</h1>
       <p className="text-lg mb-4">부동산, 주식, 채권 등 다양한 투자 방법을 소개합니다.</p>
       <ul className="list-disc pl-5 text-blue-600">
-        <li><a href="/realestate">🏠 부동산 투자</a></li>
-        <li><a href="/stock">📈 주식 투자</a></li>
-        <li><a href="/bonds">💰 채권 및 예금</a></li>
-        <li><a href="/about">ℹ️ 사이트 소개</a></li>
+        <li>
+          <Link href="/realestate">🏠 부동산 투자</Link>
+        </li>
+        <li>
+          <Link href="/stock">📈 주식 투자</Link>
+        </li>
+        <li>
+          <Link href="/bonds">💰 채권 및 예금</Link>
+        </li>
+        <li>
+          <Link href="/about">ℹ️ 사이트 소개</Link>
+        </li>
       </ul>
       <Footer />
     </main>


### PR DESCRIPTION
## Summary
- replace HTML anchor tags with Next.js `Link` components for internal navigation on the homepage
- import `Link` to ensure client-side navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896a8c864e88323a02eec5b131c52f9